### PR TITLE
✅ Close coverage gap with provider and orchestrator unit tests (Not for code review)

### DIFF
--- a/.claude/skills/coverage-guard.md
+++ b/.claude/skills/coverage-guard.md
@@ -1,0 +1,177 @@
+---
+name: coverage-guard
+description: >
+  Enforce minimum test coverage threshold for tarash-gateway. Use this skill after writing
+  or modifying code to check that unit test coverage meets the required minimum. If coverage
+  is below threshold, generates a test gap spec and invokes the orchestrate skill to
+  implement missing tests automatically.
+---
+
+# Coverage Guard
+
+Enforces a minimum test coverage threshold. When coverage falls below the threshold, generates a spec for missing tests and hands off to the orchestrate pipeline.
+
+**REQUIRED SUB-SKILL:** Load the `testing` skill before analyzing coverage gaps or generating specs. This ensures all test recommendations follow project testing conventions.
+
+---
+
+## Configuration
+
+| Setting | Value |
+|---------|-------|
+| **Threshold** | 80% |
+| **Package** | `tarash-gateway` |
+| **Test command** | `uv run pytest packages/tarash-gateway/tests/unit --cov=tarash.tarash_gateway --cov-report=json --cov-report=term-missing -q` |
+| **Coverage JSON** | `coverage.json` (repo root) |
+| **Scope** | Unit tests only |
+
+---
+
+## Execution Flow
+
+### Step 1: Load Testing Skill
+
+Before any analysis, invoke the `testing` skill to load test patterns and conventions. This informs all spec generation decisions.
+
+### Step 2: Run Coverage
+
+Run the test command:
+
+```bash
+uv run pytest packages/tarash-gateway/tests/unit --cov=tarash.tarash_gateway --cov-report=json --cov-report=term-missing -q
+```
+
+If pytest fails (non-zero exit for reasons other than coverage), report the error and **stop**. Do not generate a spec for broken tests.
+
+### Step 3: Parse Results
+
+Read `coverage.json` (written to the repo root by pytest-cov). Extract:
+- `totals.percent_covered` — the overall coverage percentage
+- Per-file breakdown: `files.<path>.summary.percent_covered`, `missing_lines`, `missing_branches`
+
+### Step 4: Decide
+
+**IF coverage >= 80%:**
+
+Print a summary and stop:
+
+```
+## Coverage Report: PASS
+
+| Metric | Value |
+|--------|-------|
+| Current coverage | XX.XX% |
+| Threshold | 80% |
+| Status | PASS |
+
+### Least Covered Files
+
+| File | Coverage | Missing Lines |
+|------|----------|---------------|
+| path/to/file1.py | XX% | N lines |
+| path/to/file2.py | XX% | N lines |
+| path/to/file3.py | XX% | N lines |
+```
+
+No further action needed.
+
+**IF coverage < 80%:**
+
+Proceed to Step 5.
+
+### Step 5: Analyze Coverage Gaps
+
+From the coverage JSON, identify all files below 80% coverage. For each file:
+
+1. Read the source file to understand what the uncovered code does
+2. Identify uncovered functions/methods and their line ranges
+3. Identify uncovered branches (if/else, try/except)
+4. Determine what behavioral tests would cover the gaps (not mechanical line-by-line tests)
+5. Map each uncovered file to its corresponding test file path in `tests/unit/`
+
+### Step 6: Generate Coverage Gap Spec
+
+Write a spec to `dev-docs/superpowers/specs/YYYY-MM-DD-coverage-gap-spec.md` with this structure:
+
+```markdown
+# Coverage Gap Spec
+
+## Coverage Summary
+
+| Metric | Value |
+|--------|-------|
+| Current coverage | XX.XX% |
+| Threshold | 80% |
+| Gap | X.XX percentage points |
+
+## Uncovered Files
+
+Ranked by missing lines (descending):
+
+| File | Coverage | Missing Lines | Missing Branches |
+|------|----------|---------------|------------------|
+| ... | ... | ... | ... |
+
+## Per-File Analysis
+
+### `path/to/file.py` (XX% covered)
+
+**Uncovered functions:**
+- `function_name` (lines X-Y): [description of what it does]
+
+**Uncovered branches:**
+- `function_name` line X: [which branch is missed, e.g., "error handling path"]
+
+**Tests to write:**
+- Test file: `tests/unit/path/to/test_file.py`
+- Behaviors to test:
+  - [behavior description 1]
+  - [behavior description 2]
+- Fixtures needed: [list any fixtures]
+- Edge cases: [list edge cases]
+
+(Repeat for each uncovered file)
+
+## Testing Conventions
+
+- Function-based tests (no classes) — per CLAUDE.md
+- Behavior-driven naming: `test_<behavior_description>`
+- Use fixtures for shared setup
+- asyncio_mode="auto" for async tests
+- Use `uv run pytest` exclusively
+- Follow patterns from the `testing` skill
+
+## Acceptance Criteria
+
+- [ ] Overall coverage meets or exceeds 80%
+- [ ] All new tests pass
+- [ ] No existing tests broken
+- [ ] Tests follow project conventions (function-based, behavior-driven)
+```
+
+### Step 7: Invoke Orchestrate
+
+Pass the spec to the orchestrate skill:
+
+```
+/orchestrate dev-docs/superpowers/specs/YYYY-MM-DD-coverage-gap-spec.md
+```
+
+The orchestrate pipeline handles: planning, TDD implementation, quality gate, and commit.
+
+---
+
+## Error Handling
+
+- **pytest fails to run:** Report the error (missing dependencies, syntax errors, etc.) and stop. Do not generate a spec.
+- **coverage.json missing or unparseable:** Report the error and stop.
+- **No unit tests exist yet:** Report 0% coverage and generate a spec for initial test coverage.
+
+---
+
+## What This Skill Does NOT Do
+
+- Does not write tests itself — delegates to orchestrate
+- Does not modify the threshold — 80% is the default
+- Does not run e2e tests — unit coverage only
+- Does not auto-trigger — Claude invokes based on CLAUDE.md directive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,3 +235,7 @@ class TestHandleMockRequestSync:
 - No need for `self` parameter clutter
 - Better pytest output with flat structure
 - Fixtures provide all the shared setup benefits of classes without the overhead
+
+### Test Coverage Enforcement
+
+- After writing or modifying code, invoke the `coverage-guard` skill to ensure test coverage meets the threshold.

--- a/packages/tarash-gateway/tests/unit/image/providers/test_google.py
+++ b/packages/tarash-gateway/tests/unit/image/providers/test_google.py
@@ -217,3 +217,280 @@ def test_google_provider_registered_in_registry():
     with patch("tarash.tarash_gateway.providers.google.has_genai", True):
         handler = get_handler(config)
         assert isinstance(handler, GoogleProviderHandler)
+
+
+# ==================== _bytes_to_data_uri Tests ====================
+
+
+def test_bytes_to_data_uri_with_bytes():
+    """Test _bytes_to_data_uri encodes bytes to data URI."""
+    from tarash.tarash_gateway.providers.google import _bytes_to_data_uri
+    import base64
+
+    img_bytes = b"fake-image-data"
+    result = _bytes_to_data_uri(img_bytes, "image/png")
+
+    expected = f"data:image/png;base64,{base64.b64encode(img_bytes).decode()}"
+    assert result == expected
+
+
+def test_bytes_to_data_uri_with_string():
+    """Test _bytes_to_data_uri encodes string input to data URI."""
+    from tarash.tarash_gateway.providers.google import _bytes_to_data_uri
+    import base64
+
+    img_string = "fake-image-data"
+    result = _bytes_to_data_uri(img_string, "image/jpeg")
+
+    expected_bytes = img_string.encode()
+    expected = f"data:image/jpeg;base64,{base64.b64encode(expected_bytes).decode()}"
+    assert result == expected
+
+
+def test_bytes_to_data_uri_default_mime_type():
+    """Test _bytes_to_data_uri uses default image/png mime type."""
+    from tarash.tarash_gateway.providers.google import _bytes_to_data_uri
+
+    result = _bytes_to_data_uri(b"data")
+    assert result.startswith("data:image/png;base64,")
+
+
+# ==================== _is_gemini_image_model Tests ====================
+
+
+def test_is_gemini_image_model_true():
+    """Test _is_gemini_image_model returns True for Gemini image models."""
+    from tarash.tarash_gateway.providers.google import _is_gemini_image_model
+
+    assert _is_gemini_image_model("gemini-2.5-flash-image") is True
+    assert _is_gemini_image_model("gemini-3-pro-image-preview") is True
+
+
+def test_is_gemini_image_model_false():
+    """Test _is_gemini_image_model returns False for non-Gemini models."""
+    from tarash.tarash_gateway.providers.google import _is_gemini_image_model
+
+    assert _is_gemini_image_model("imagen-3.0-generate-001") is False
+    assert _is_gemini_image_model("gemini-2.5-flash") is False  # No 'image' in name
+
+
+# ==================== Imagen Response Conversion: inline_data ====================
+
+
+def test_convert_image_response_with_inline_data(handler, base_config):
+    """Test Imagen response conversion with inline_data (image_bytes)."""
+
+    request_id = "req-inline"
+
+    mock_image = MagicMock()
+    mock_image.image.gcs_uri = None
+    mock_image.image.image_bytes = b"fake-image-bytes"
+    mock_image.image.mime_type = "image/jpeg"
+
+    # gcs_uri is None, so it should use image_bytes path
+    mock_response = {
+        "generated_images": [mock_image],
+    }
+
+    result = handler._convert_image_response(base_config, request_id, mock_response)
+
+    assert result.request_id == request_id
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    # Should be a data URI
+    assert result.images[0].startswith("data:image/jpeg;base64,")
+
+
+def test_convert_image_response_empty_list(handler, base_config):
+    """Test Imagen response with no generated images."""
+    result = handler._convert_image_response(
+        base_config, "req-empty", {"generated_images": []}
+    )
+
+    assert result.images == []
+
+
+# ==================== Gemini Image Response Conversion ====================
+
+
+def test_convert_gemini_image_response_with_parts(handler, base_config):
+    """Test Gemini response conversion from parts with inline_data."""
+
+    mock_inline_data = MagicMock()
+    mock_inline_data.data = b"gemini-image-bytes"
+    mock_inline_data.mime_type = "image/png"
+
+    mock_part = MagicMock()
+    mock_part.inline_data = mock_inline_data
+
+    mock_response = MagicMock()
+    mock_response.parts = [mock_part]
+    mock_response.model_dump.return_value = {"parts": []}
+
+    result = handler._convert_gemini_image_response(
+        base_config, "req-gemini", mock_response
+    )
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert result.images[0].startswith("data:image/png;base64,")
+
+
+def test_convert_gemini_image_response_no_parts(handler, base_config):
+    """Test Gemini response with no parts returns empty images."""
+    mock_response = MagicMock()
+    mock_response.parts = []
+    mock_response.model_dump.return_value = {"parts": []}
+
+    result = handler._convert_gemini_image_response(
+        base_config, "req-no-parts", mock_response
+    )
+
+    assert result.images == []
+
+
+def test_convert_gemini_image_response_no_inline_data(handler, base_config):
+    """Test Gemini response with parts but no inline_data is skipped."""
+    mock_part = MagicMock()
+    mock_part.inline_data = None
+
+    mock_response = MagicMock()
+    mock_response.parts = [mock_part]
+    mock_response.model_dump.return_value = {}
+
+    result = handler._convert_gemini_image_response(
+        base_config, "req-no-inline", mock_response
+    )
+
+    assert result.images == []
+
+
+def test_convert_gemini_image_response_without_model_dump(handler, base_config):
+    """Test Gemini response without model_dump uses string fallback."""
+    mock_response = MagicMock(spec=[])  # No model_dump
+    mock_response.parts = []
+
+    result = handler._convert_gemini_image_response(
+        base_config, "req-no-dump", mock_response
+    )
+
+    assert result.images == []
+    assert "response" in result.raw_response
+
+
+# ==================== Image Generation: async/sync ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_imagen(handler, base_config, base_request):
+    """Test async image generation with Imagen model."""
+    mock_gen_image = MagicMock()
+    mock_gen_image.image.gcs_uri = "https://storage.googleapis.com/image.png"
+
+    mock_imagen_response = MagicMock()
+    mock_imagen_response.generated_images = [mock_gen_image]
+
+    mock_client = AsyncMock()
+    mock_client.models.generate_images = AsyncMock(return_value=mock_imagen_response)
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        result = await handler.generate_image_async(base_config, base_request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert result.images[0] == "https://storage.googleapis.com/image.png"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_gemini(handler, nano_banana_config, base_request):
+    """Test async image generation with Gemini (Nano Banana) model."""
+    mock_inline_data = MagicMock()
+    mock_inline_data.data = b"gemini-image"
+    mock_inline_data.mime_type = "image/png"
+
+    mock_part = MagicMock()
+    mock_part.inline_data = mock_inline_data
+
+    mock_response = MagicMock()
+    mock_response.parts = [mock_part]
+    mock_response.model_dump.return_value = {}
+
+    mock_client = AsyncMock()
+    mock_client.models.generate_content = AsyncMock(return_value=mock_response)
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        result = await handler.generate_image_async(nano_banana_config, base_request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert result.images[0].startswith("data:image/png;base64,")
+
+
+def test_generate_image_sync_imagen(handler, base_config, base_request):
+    """Test sync image generation with Imagen model."""
+    mock_gen_image = MagicMock()
+    mock_gen_image.image.gcs_uri = "https://storage.googleapis.com/image.png"
+
+    mock_imagen_response = MagicMock()
+    mock_imagen_response.generated_images = [mock_gen_image]
+
+    mock_client = MagicMock()
+    mock_client.models.generate_images = MagicMock(return_value=mock_imagen_response)
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        result = handler.generate_image(base_config, base_request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+
+
+def test_generate_image_sync_gemini(handler, nano_banana_config, base_request):
+    """Test sync image generation with Gemini model."""
+    mock_inline_data = MagicMock()
+    mock_inline_data.data = b"gemini-image"
+    mock_inline_data.mime_type = "image/png"
+
+    mock_part = MagicMock()
+    mock_part.inline_data = mock_inline_data
+
+    mock_response = MagicMock()
+    mock_response.parts = [mock_part]
+    mock_response.model_dump.return_value = {}
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content = MagicMock(return_value=mock_response)
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        result = handler.generate_image(nano_banana_config, base_request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_error_handling(handler, base_config, base_request):
+    """Test async image generation error handling."""
+    from tarash.tarash_gateway.exceptions import GenerationFailedError
+
+    mock_client = AsyncMock()
+    mock_client.models.generate_images = AsyncMock(
+        side_effect=RuntimeError("API failure")
+    )
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        with pytest.raises(GenerationFailedError):
+            await handler.generate_image_async(base_config, base_request)
+
+
+def test_generate_image_sync_error_handling(handler, base_config, base_request):
+    """Test sync image generation error handling."""
+    from tarash.tarash_gateway.exceptions import GenerationFailedError
+
+    mock_client = MagicMock()
+    mock_client.models.generate_images = MagicMock(
+        side_effect=RuntimeError("API failure")
+    )
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        with pytest.raises(GenerationFailedError):
+            handler.generate_image(base_config, base_request)

--- a/packages/tarash-gateway/tests/unit/image/providers/test_stability.py
+++ b/packages/tarash-gateway/tests/unit/image/providers/test_stability.py
@@ -459,3 +459,252 @@ def test_generate_video_sync_not_supported(handler):
     """Test that sync video generation raises NotImplementedError."""
     with pytest.raises(NotImplementedError, match="does not support video"):
         handler.generate_video(None, None)
+
+
+# ==================== Error Handling Tests ====================
+
+
+def test_handle_error_tarash_exception_passes_through(
+    handler, base_config, base_request
+):
+    """Test TarashException passes through unchanged."""
+    from tarash.tarash_gateway.exceptions import ValidationError
+
+    ex = ValidationError("test", provider="stability")
+    result = handler._handle_error(base_config, base_request, "req-1", ex)
+    assert result is ex
+
+
+def test_handle_error_http_status_400(handler, base_config, base_request):
+    """Test HTTPStatusError 400 maps to ValidationError."""
+    import httpx
+
+    mock_response = httpx.Response(
+        status_code=400,
+        text="Bad request: invalid prompt",
+        request=httpx.Request("POST", "https://api.stability.ai/v2beta/test"),
+    )
+    ex = httpx.HTTPStatusError(
+        "400 Bad Request", request=mock_response.request, response=mock_response
+    )
+
+    result = handler._handle_error(base_config, base_request, "req-400", ex)
+
+    from tarash.tarash_gateway.exceptions import ValidationError
+
+    assert isinstance(result, ValidationError)
+    assert "Invalid request" in result.message
+    assert result.raw_response["status_code"] == 400
+
+
+def test_handle_error_http_status_422(handler, base_config, base_request):
+    """Test HTTPStatusError 422 maps to ValidationError."""
+    import httpx
+
+    mock_response = httpx.Response(
+        status_code=422,
+        text="Unprocessable entity",
+        request=httpx.Request("POST", "https://api.stability.ai/v2beta/test"),
+    )
+    ex = httpx.HTTPStatusError(
+        "422 Unprocessable", request=mock_response.request, response=mock_response
+    )
+
+    result = handler._handle_error(base_config, base_request, "req-422", ex)
+
+    from tarash.tarash_gateway.exceptions import ValidationError
+
+    assert isinstance(result, ValidationError)
+
+
+def test_handle_error_http_status_500(handler, base_config, base_request):
+    """Test HTTPStatusError 500 maps to HTTPError."""
+    import httpx
+
+    mock_response = httpx.Response(
+        status_code=500,
+        text="Internal server error",
+        request=httpx.Request("POST", "https://api.stability.ai/v2beta/test"),
+    )
+    ex = httpx.HTTPStatusError(
+        "500 Server Error", request=mock_response.request, response=mock_response
+    )
+
+    result = handler._handle_error(base_config, base_request, "req-500", ex)
+
+    from tarash.tarash_gateway.exceptions import HTTPError
+
+    assert isinstance(result, HTTPError)
+    assert result.status_code == 500
+
+
+def test_handle_error_unknown_exception(handler, base_config, base_request):
+    """Test unknown exception maps to TarashException."""
+    from tarash.tarash_gateway.exceptions import TarashException
+
+    ex = RuntimeError("something unexpected")
+    result = handler._handle_error(base_config, base_request, "req-unk", ex)
+
+    assert isinstance(result, TarashException)
+    assert "Error during image generation" in result.message
+
+
+# ==================== Endpoint Routing Tests ====================
+
+
+def test_get_endpoint_sd3_model(handler):
+    """Test SD3 model routes to SD3 endpoint."""
+    result = handler._get_endpoint_for_model("sd3.5-large")
+    assert result == "/v2beta/stable-image/generate/sd3"
+
+
+def test_get_endpoint_sd3_medium(handler):
+    """Test SD3 medium model routes to SD3 endpoint."""
+    result = handler._get_endpoint_for_model("sd3.5-medium")
+    assert result == "/v2beta/stable-image/generate/sd3"
+
+
+def test_get_endpoint_ultra(handler):
+    """Test stable-image-ultra routes to ultra endpoint."""
+    result = handler._get_endpoint_for_model("stable-image-ultra")
+    assert result == "/v2beta/stable-image/generate/ultra"
+
+
+def test_get_endpoint_core(handler):
+    """Test stable-image-core routes to core endpoint."""
+    result = handler._get_endpoint_for_model("stable-image-core")
+    assert result == "/v2beta/stable-image/generate/core"
+
+
+def test_get_endpoint_unknown_defaults_to_sd3(handler):
+    """Test unknown model defaults to SD3 endpoint."""
+    result = handler._get_endpoint_for_model("unknown-model")
+    assert result == "/v2beta/stable-image/generate/sd3"
+
+
+# ==================== SD3 Model Variant Selection ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_sd3_turbo_variant(handler):
+    """Test SD3 turbo variant sets correct model name."""
+    config = ImageGenerationConfig(
+        model="sd3.5-large-turbo",
+        provider="stability",
+        api_key="test-api-key",
+        timeout=120,
+    )
+    request = ImageGenerationRequest(prompt="A sunset")
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.content = b"fake-image"
+        mock_response.headers = {"content-type": "image/png"}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        await handler.generate_image_async(config, request)
+
+        call_kwargs = mock_client.post.call_args
+        # Verify model param was set to sd3.5-large-turbo
+        assert call_kwargs[1]["data"]["model"] == "sd3.5-large-turbo"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_sd3_medium_variant(handler):
+    """Test SD3 medium variant sets correct model name."""
+    config = ImageGenerationConfig(
+        model="sd3.5-medium",
+        provider="stability",
+        api_key="test-api-key",
+        timeout=120,
+    )
+    request = ImageGenerationRequest(prompt="A mountain")
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.content = b"fake-image"
+        mock_response.headers = {"content-type": "image/png"}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        await handler.generate_image_async(config, request)
+
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs[1]["data"]["model"] == "sd3.5-medium"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_error_handling(handler, base_config, base_request):
+    """Test async image generation error handling."""
+    import httpx
+
+    mock_response = httpx.Response(
+        status_code=500,
+        text="Server error",
+        request=httpx.Request("POST", "https://api.stability.ai/v2beta/test"),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=mock_response.request, response=mock_response
+            )
+        )
+        mock_client_class.return_value = mock_client
+
+        from tarash.tarash_gateway.exceptions import HTTPError
+
+        with pytest.raises(HTTPError):
+            await handler.generate_image_async(base_config, base_request)
+
+
+def test_generate_image_sync_error_handling(handler, base_config, base_request):
+    """Test sync image generation error handling."""
+    import httpx
+
+    mock_response = httpx.Response(
+        status_code=400,
+        text="Bad request",
+        request=httpx.Request("POST", "https://api.stability.ai/v2beta/test"),
+    )
+
+    with patch("httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "400", request=mock_response.request, response=mock_response
+            )
+        )
+        mock_client_class.return_value = mock_client
+
+        from tarash.tarash_gateway.exceptions import ValidationError
+
+        with pytest.raises(ValidationError):
+            handler.generate_image(base_config, base_request)
+
+
+# ==================== Field Mapper Non-Dict Input ====================
+
+
+def test_cfg_scale_field_mapper_non_dict_returns_none():
+    """Test cfg_scale field mapper returns None for non-dict input."""
+    request = ImageGenerationRequest(prompt="A sunset")
+    # When extra_params is None, the converter receives None
+    result = apply_field_mappers(SD35_LARGE_FIELD_MAPPERS, request)
+    # cfg_scale should not be in result when extra_params has no cfg_scale
+    assert "cfg_scale" not in result
+
+
+def test_steps_field_mapper_non_dict_returns_none():
+    """Test steps field mapper returns None for non-dict input."""
+    request = ImageGenerationRequest(prompt="A sunset")
+    result = apply_field_mappers(SD35_LARGE_FIELD_MAPPERS, request)
+    assert "steps" not in result

--- a/packages/tarash-gateway/tests/unit/video/providers/test_fal.py
+++ b/packages/tarash-gateway/tests/unit/video/providers/test_fal.py
@@ -3445,3 +3445,241 @@ def test_seedream_v5_lite_edit_conversion(handler):
     ]
     assert result["num_images"] == 1
     assert result["image_size"] == "auto_2K"
+
+
+# ==================== Error Handling: httpx timeout/connection ====================
+
+
+def test_handle_error_httpx_timeout(handler, base_config, base_request):
+    """Test httpx.TimeoutException maps to TimeoutError."""
+    import httpx
+
+    from tarash.tarash_gateway.exceptions import TimeoutError
+
+    ex = httpx.ReadTimeout("Request timed out")
+    result = handler._handle_error(base_config, base_request, "req-timeout", ex)
+
+    assert isinstance(result, TimeoutError)
+    assert "timed out" in result.message
+    assert result.provider == "fal"
+
+
+def test_handle_error_httpx_connect_error(handler, base_config, base_request):
+    """Test httpx.ConnectError maps to HTTPConnectionError."""
+    import httpx
+
+    from tarash.tarash_gateway.exceptions import HTTPConnectionError
+
+    ex = httpx.ConnectError("Connection refused")
+    result = handler._handle_error(base_config, base_request, "req-conn", ex)
+
+    assert isinstance(result, HTTPConnectionError)
+    assert "Connection error" in result.message
+
+
+def test_handle_error_tarash_exception_passthrough(handler, base_config, base_request):
+    """Test TarashException passes through unchanged."""
+    ex = ValidationError("test", provider="fal")
+    result = handler._handle_error(base_config, base_request, "req-1", ex)
+    assert result is ex
+
+
+def test_handle_error_unknown_exception(handler, base_config, base_request):
+    """Test unknown exception maps to GenerationFailedError."""
+    ex = RuntimeError("something unexpected")
+    result = handler._handle_error(base_config, base_request, "req-unk", ex)
+    assert isinstance(result, GenerationFailedError)
+    assert "Error while generating video" in result.message
+
+
+# ==================== Image Response Conversion ====================
+
+
+def test_convert_image_response_dict_images(handler):
+    """Test image response conversion with dict images having url key."""
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    fal_result = {
+        "images": [
+            {"url": "https://example.com/img1.png", "content_type": "image/png"},
+            {"url": "https://example.com/img2.png"},
+        ],
+    }
+
+    result = handler._convert_image_response(config, request, "req-img", fal_result)
+
+    assert result.status == "completed"
+    assert len(result.images) == 2
+    assert result.images[0] == "https://example.com/img1.png"
+    assert result.images[1] == "https://example.com/img2.png"
+
+
+def test_convert_image_response_string_images(handler):
+    """Test image response conversion with string image URLs."""
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    fal_result = {
+        "images": [
+            "https://example.com/img1.png",
+            "https://example.com/img2.png",
+        ],
+    }
+
+    result = handler._convert_image_response(config, request, "req-str", fal_result)
+
+    assert len(result.images) == 2
+    assert result.images[0] == "https://example.com/img1.png"
+
+
+def test_convert_image_response_with_revised_prompt(handler):
+    """Test image response conversion includes revised_prompt."""
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    fal_result = {
+        "images": [{"url": "https://example.com/img.png"}],
+        "revised_prompt": "Enhanced: test",
+    }
+
+    result = handler._convert_image_response(config, request, "req-rev", fal_result)
+
+    assert result.revised_prompt == "Enhanced: test"
+
+
+def test_convert_image_response_empty_images(handler):
+    """Test image response conversion with no images."""
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    fal_result = {}
+
+    result = handler._convert_image_response(config, request, "req-empty", fal_result)
+
+    assert result.images == []
+
+
+# ==================== Image Generation: async/sync ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_success(handler):
+    """Test async image generation with mocked Fal client."""
+    from fal_client import Completed
+
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+        timeout=120,
+        max_poll_attempts=5,
+        poll_interval=1,
+    )
+    request = ImageGenerationRequest(prompt="A sunset")
+
+    mock_handle = AsyncMock()
+    mock_handle.request_id = "fal-img-123"
+
+    # Mock status returning Completed
+    completed = Completed(metrics={}, logs=[])
+    mock_handle.status = AsyncMock(return_value=completed)
+    mock_handle.get = AsyncMock(
+        return_value={
+            "images": [{"url": "https://example.com/image.png"}],
+        }
+    )
+
+    mock_client = AsyncMock()
+    mock_client.submit = AsyncMock(return_value=mock_handle)
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        result = await handler.generate_image_async(config, request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert result.images[0] == "https://example.com/image.png"
+
+
+def test_generate_image_sync_success(handler):
+    """Test sync image generation with mocked Fal client."""
+    from fal_client import Completed
+
+    config = ImageGenerationConfig(
+        model="fal-ai/nano-banana-2",
+        provider="fal",
+        api_key="test-key",
+        timeout=120,
+        max_poll_attempts=5,
+        poll_interval=1,
+    )
+    request = ImageGenerationRequest(prompt="A mountain")
+
+    mock_handle = MagicMock()
+    mock_handle.request_id = "fal-img-sync"
+
+    completed = Completed(metrics={}, logs=[])
+    mock_handle.status.return_value = completed
+    mock_handle.get.return_value = {
+        "images": [{"url": "https://example.com/image.png"}],
+    }
+
+    mock_client = MagicMock()
+    mock_client.submit.return_value = mock_handle
+
+    with patch.object(handler, "_get_client", return_value=mock_client):
+        with patch("time.sleep"):
+            result = handler.generate_image(config, request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+
+
+# ==================== TTS Duration Extraction Fallback ====================
+
+
+def test_extract_tts_duration_top_level_seconds():
+    """Test _extract_tts_duration with top-level duration (seconds fallback)."""
+    from tarash.tarash_gateway.providers.fal import _extract_tts_duration
+
+    result = _extract_tts_duration({"duration": 5.5})
+    assert result == 5.5
+
+
+def test_extract_tts_duration_none_when_no_duration():
+    """Test _extract_tts_duration returns None when no duration found."""
+    from tarash.tarash_gateway.providers.fal import _extract_tts_duration
+
+    result = _extract_tts_duration({"some_field": "value"})
+    assert result is None
+
+
+# ==================== TTS Status Parsing: Unknown Status ====================
+
+
+def test_parse_fal_tts_status_unknown_raises_value_error():
+    """Test parse_fal_tts_status with unknown status raises ValueError."""
+    from tarash.tarash_gateway.providers.fal import parse_fal_tts_status
+
+    unknown_status = MagicMock()
+    # Make it NOT an instance of Completed, Queued, or InProgress
+    unknown_status.__class__ = type("UnknownStatus", (), {})
+
+    with pytest.raises(ValueError, match="Unknown status"):
+        parse_fal_tts_status("req-1", unknown_status)

--- a/packages/tarash-gateway/tests/unit/video/providers/test_openai.py
+++ b/packages/tarash-gateway/tests/unit/video/providers/test_openai.py
@@ -6,6 +6,8 @@ import pytest
 
 from tarash.tarash_gateway.exceptions import (
     GenerationFailedError,
+    HTTPConnectionError,
+    HTTPError,
     TimeoutError,
     ValidationError,
 )
@@ -962,3 +964,332 @@ def test_generate_image_sync_gpt_image_15_success(handler):
     assert response.images[0] == "https://example.com/image1.png"
     assert response.images[1] == "https://example.com/image2.png"
     assert response.status == "completed"
+
+
+# ==================== Error Handling: APITimeoutError, APIConnectionError, APIStatusError ====================
+
+
+def test_handle_error_api_timeout(handler, base_config, base_request):
+    """Test APITimeoutError maps to TimeoutError."""
+    from openai import APITimeoutError
+
+    ex = APITimeoutError.__new__(APITimeoutError)
+    ex.args = ("Request timed out",)
+
+    result = handler._handle_error(base_config, base_request, "req-t", ex)
+
+    assert isinstance(result, TimeoutError)
+    assert "timed out" in result.message
+    assert result.provider == "openai"
+    assert result.timeout_seconds == 600
+
+
+def test_handle_error_api_connection_error(handler, base_config, base_request):
+    """Test APIConnectionError maps to HTTPConnectionError."""
+    from openai import APIConnectionError
+
+    ex = APIConnectionError.__new__(APIConnectionError)
+    ex.args = ("Connection refused",)
+
+    result = handler._handle_error(base_config, base_request, "req-c", ex)
+
+    assert isinstance(result, HTTPConnectionError)
+    assert "Connection error" in result.message
+
+
+def test_handle_error_api_status_error_400_validation(
+    handler, base_config, base_request
+):
+    """Test BadRequestError (400) maps to ValidationError."""
+    from openai import BadRequestError
+
+    ex = BadRequestError.__new__(BadRequestError)
+    ex.status_code = 400
+    ex.message = "Invalid parameter"
+    ex.body = {"message": "Invalid prompt"}
+    ex.type = "invalid_request_error"
+    ex.param = "prompt"
+    ex.code = "invalid_parameter"
+    ex.args = ("Invalid parameter",)
+
+    result = handler._handle_error(base_config, base_request, "req-400", ex)
+
+    assert isinstance(result, ValidationError)
+    assert result.message == "Invalid prompt"  # Extracted from body
+
+
+def test_handle_error_api_status_error_body_dict_no_message(
+    handler, base_config, base_request
+):
+    """Test APIStatusError with body dict but no message key uses ex.message."""
+    from openai import APIStatusError
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.json.return_value = {}
+    mock_response.headers = {}
+    mock_response.text = ""
+
+    ex = APIStatusError.__new__(APIStatusError)
+    ex.status_code = 500
+    ex.message = "Server error fallback"
+    ex.body = {"error": "no message key"}
+    ex.type = None
+    ex.param = None
+    ex.code = None
+    ex.response = mock_response
+    ex.args = ("Server error",)
+
+    result = handler._handle_error(base_config, base_request, "req-500", ex)
+
+    assert isinstance(result, HTTPError)
+    assert result.status_code == 500
+    assert result.message == "Server error fallback"
+
+
+def test_handle_error_api_status_error_non_dict_body(
+    handler, base_config, base_request
+):
+    """Test APIStatusError with non-dict body uses ex.message."""
+    from openai import APIStatusError
+
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.headers = {}
+    mock_response.text = ""
+
+    ex = APIStatusError.__new__(APIStatusError)
+    ex.status_code = 429
+    ex.message = "Rate limited"
+    ex.body = "rate_limited"  # non-dict body
+    ex.type = None
+    ex.param = None
+    ex.code = None
+    ex.response = mock_response
+    ex.args = ("Rate limited",)
+
+    result = handler._handle_error(base_config, base_request, "req-429", ex)
+
+    assert isinstance(result, HTTPError)
+    assert result.status_code == 429
+    assert result.message == "Rate limited"
+
+
+# ==================== Validate Params: Empty extra_params ====================
+
+
+def test_validate_params_with_none_extra_params(handler, base_config):
+    """Test validation with None extra_params returns empty dict."""
+    request = VideoGenerationRequest(prompt="test")
+    # Ensure extra_params is empty
+    assert handler._validate_params(base_config, request) == {}
+
+
+# ==================== Invalid Aspect Ratio ====================
+
+
+def test_convert_request_invalid_aspect_ratio(handler, base_config):
+    """Test unsupported aspect ratio for OpenAI raises ValidationError."""
+    # 4:3 is valid in the Pydantic model but not supported by OpenAI Sora
+    request = VideoGenerationRequest(prompt="Test", aspect_ratio="4:3")
+    with pytest.raises(ValidationError, match="Invalid aspect ratio"):
+        handler._convert_request(base_config, request)
+
+
+# ==================== Image-to-Video Flow ====================
+
+
+def test_convert_request_image_to_video_with_bytes(handler, base_config):
+    """Test image-to-video conversion with MediaContent bytes dict."""
+    request = VideoGenerationRequest(
+        prompt="Animate this image",
+        image_list=[
+            {
+                "type": "reference",
+                "image": {
+                    "content": b"fake-image-bytes",
+                    "content_type": "image/jpeg",
+                },
+            }
+        ],
+    )
+    result = handler._convert_request(base_config, request)
+
+    # Should have input_reference as BytesIO
+    assert "input_reference" in result
+    import io
+
+    assert isinstance(result["input_reference"], io.BytesIO)
+
+
+def test_convert_request_image_to_video_with_url(handler, base_config):
+    """Test image-to-video conversion with URL downloads the image."""
+    request = VideoGenerationRequest(
+        prompt="Animate",
+        image_list=[
+            {
+                "type": "reference",
+                "image": "https://example.com/image.jpg",
+            }
+        ],
+    )
+    with patch(
+        "tarash.tarash_gateway.providers.openai.download_media_from_url",
+        return_value=(b"downloaded-bytes", "image/jpeg"),
+    ):
+        result = handler._convert_request(base_config, request)
+
+    assert "input_reference" in result
+
+
+def test_convert_request_image_to_video_multiple_images_error(handler, base_config):
+    """Test more than 1 image raises ValidationError."""
+    request = VideoGenerationRequest(
+        prompt="Animate",
+        image_list=[
+            {"type": "reference", "image": "https://example.com/img1.jpg"},
+            {"type": "reference", "image": "https://example.com/img2.jpg"},
+        ],
+    )
+    with pytest.raises(ValidationError, match="only supports 1 reference image"):
+        handler._convert_request(base_config, request)
+
+
+# ==================== Download Video Sync: non-completed ====================
+
+
+def test_download_video_sync_non_completed_returns_none(handler, base_config):
+    """Test _download_video_sync returns (None, None) for non-completed video."""
+    from tarash.tarash_gateway.logging import ProviderLogger
+
+    mock_video = MagicMock()
+    mock_video.id = "video-incomplete"
+    mock_video.status = "in_progress"
+
+    logger = ProviderLogger("openai", "sora-2", "test")
+
+    content, content_type = handler._download_video_sync(
+        MagicMock(), mock_video, logger
+    )
+
+    assert content is None
+    assert content_type is None
+
+
+# ==================== Log Poll Status ====================
+
+
+def test_log_poll_status_returns_last_logged_progress(handler, base_config):
+    """Test _log_poll_status returns last_logged_progress value."""
+    from tarash.tarash_gateway.logging import ProviderLogger
+
+    mock_video = MagicMock()
+    mock_video.status = "in_progress"
+    mock_video.progress = 50
+
+    logger = ProviderLogger("openai", "sora-2", "test")
+
+    result = handler._log_poll_status(logger, mock_video, 0, 10, -1)
+
+    assert isinstance(result, int)
+
+
+# ==================== Remix Flow ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_video_async_remix_removes_model(handler, base_config):
+    """Test remix flow removes 'model' from params."""
+    mock_video_completed = MagicMock()
+    mock_video_completed.id = "video-remix"
+    mock_video_completed.status = "completed"
+    mock_video_completed.progress = 100
+    mock_video_completed.model_dump.return_value = {"id": "video-remix"}
+    mock_video_completed.seconds = "8"
+    mock_video_completed.size = "1280x720"
+
+    mock_download_response = AsyncMock()
+    mock_download_response.response.aread = AsyncMock(return_value=b"video content")
+
+    mock_async_client = AsyncMock()
+    mock_async_client.videos.remix = AsyncMock(return_value=mock_video_completed)
+    mock_async_client.videos.retrieve = AsyncMock(return_value=mock_video_completed)
+    mock_async_client.videos.download_content = AsyncMock(
+        return_value=mock_download_response
+    )
+
+    request = VideoGenerationRequest(
+        prompt="Remix this video",
+        extra_params={"video_id": "existing-video-id"},
+    )
+
+    with patch(
+        "tarash.tarash_gateway.providers.openai.AsyncOpenAI",
+        return_value=mock_async_client,
+    ):
+        result = await handler.generate_video_async(base_config, request)
+
+    assert result.request_id == "video-remix"
+    mock_async_client.videos.remix.assert_called_once()
+    # Verify 'model' is NOT in the remix params
+    call_kwargs = mock_async_client.videos.remix.call_args.kwargs
+    assert "model" not in call_kwargs
+    assert call_kwargs["video_id"] == "existing-video-id"
+
+
+# ==================== Image Generation Error Handling ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_error_handling(handler):
+    """Test async image generation error handling delegates to _handle_error."""
+    from tarash.tarash_gateway.models import (
+        ImageGenerationConfig,
+        ImageGenerationRequest,
+    )
+
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="test-api-key",
+        timeout=120,
+    )
+    request = ImageGenerationRequest(prompt="Test")
+
+    mock_async_client = AsyncMock()
+    mock_async_client.images.generate = AsyncMock(
+        side_effect=RuntimeError("API failed")
+    )
+
+    with patch(
+        "tarash.tarash_gateway.providers.openai.AsyncOpenAI",
+        return_value=mock_async_client,
+    ):
+        with pytest.raises(GenerationFailedError, match="Error while generating video"):
+            await handler.generate_image_async(config, request)
+
+
+def test_generate_image_sync_error_handling(handler):
+    """Test sync image generation error handling delegates to _handle_error."""
+    from tarash.tarash_gateway.models import (
+        ImageGenerationConfig,
+        ImageGenerationRequest,
+    )
+
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="test-api-key",
+        timeout=120,
+    )
+    request = ImageGenerationRequest(prompt="Test")
+
+    mock_sync_client = MagicMock()
+    mock_sync_client.images.generate.side_effect = RuntimeError("API failed")
+
+    with patch(
+        "tarash.tarash_gateway.providers.openai.OpenAI",
+        return_value=mock_sync_client,
+    ):
+        with pytest.raises(GenerationFailedError, match="Error while generating video"):
+            handler.generate_image(config, request)

--- a/packages/tarash-gateway/tests/unit/video/providers/test_replicate.py
+++ b/packages/tarash-gateway/tests/unit/video/providers/test_replicate.py
@@ -6,9 +6,14 @@ import pytest
 
 from tarash.tarash_gateway.exceptions import (
     GenerationFailedError,
+    HTTPConnectionError,
+    HTTPError,
     TimeoutError,
+    ValidationError,
 )
 from tarash.tarash_gateway.models import (
+    ImageGenerationConfig,
+    ImageGenerationRequest,
     VideoGenerationConfig,
     VideoGenerationRequest,
 )
@@ -1342,3 +1347,405 @@ def test_convert_image_response_with_none_output_raises_error(handler):
 
     with pytest.raises(GenerationFailedError, match="no output was returned"):
         handler._convert_image_response(config, request, "pred-null", None)
+
+
+# ==================== Error Handling: APITimeoutError ====================
+
+
+def test_handle_error_api_timeout(handler, base_config, base_request):
+    """Test APITimeoutError maps to TimeoutError."""
+    import replicate
+
+    ex = replicate.APITimeoutError.__new__(replicate.APITimeoutError)
+    ex.args = ("Request timed out",)
+
+    result = handler._handle_error(base_config, base_request, "pred-timeout", ex)
+
+    assert isinstance(result, TimeoutError)
+    assert "timed out" in result.message
+    assert result.provider == "replicate"
+    assert result.request_id == "pred-timeout"
+
+
+def test_handle_error_api_connection_error(handler, base_config, base_request):
+    """Test APIConnectionError maps to HTTPConnectionError."""
+    import replicate
+
+    ex = replicate.APIConnectionError.__new__(replicate.APIConnectionError)
+    ex.args = ("Connection refused",)
+
+    result = handler._handle_error(base_config, base_request, "pred-conn", ex)
+
+    assert isinstance(result, HTTPConnectionError)
+    assert "Connection error" in result.message
+    assert result.provider == "replicate"
+
+
+def test_handle_error_api_status_error_400(handler, base_config, base_request):
+    """Test BadRequestError (400) maps to ValidationError."""
+    import replicate
+
+    ex = replicate.BadRequestError.__new__(replicate.BadRequestError)
+    ex.status_code = 400
+    ex.message = "Invalid input format"
+    ex.body = {"error": "Invalid input format"}
+    ex.args = ("Invalid input format",)
+
+    result = handler._handle_error(base_config, base_request, "pred-400", ex)
+
+    assert isinstance(result, ValidationError)
+    assert result.raw_response["status_code"] == 400
+
+
+def test_handle_error_api_status_error_422(handler, base_config, base_request):
+    """Test UnprocessableEntityError (422) maps to ValidationError."""
+    import replicate
+
+    ex = replicate.UnprocessableEntityError.__new__(replicate.UnprocessableEntityError)
+    ex.status_code = 422
+    ex.message = "Unprocessable entity"
+    ex.body = {"error": "Unprocessable entity"}
+    ex.args = ("Unprocessable entity",)
+
+    result = handler._handle_error(base_config, base_request, "pred-422", ex)
+
+    assert isinstance(result, ValidationError)
+
+
+def test_handle_error_api_status_error_500(handler, base_config, base_request):
+    """Test generic APIStatusError (500) maps to HTTPError."""
+    import replicate
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.json.return_value = {"error": "Internal server error"}
+    mock_response.headers = {}
+    mock_response.text = "Internal server error"
+
+    ex = replicate.APIStatusError.__new__(replicate.APIStatusError)
+    ex.status_code = 500
+    ex.message = "Internal server error"
+    ex.body = {"error": "Internal server error"}
+    ex.response = mock_response
+    ex.args = ("Internal server error",)
+
+    result = handler._handle_error(base_config, base_request, "pred-500", ex)
+
+    assert isinstance(result, HTTPError)
+    assert result.status_code == 500
+
+
+# ==================== Response Conversion: FileOutput objects ====================
+
+
+def test_convert_response_with_file_output_read_in_list(
+    handler, base_config, base_request
+):
+    """Test conversion when list contains FileOutput objects with .read() method."""
+
+    class FakeFileOutput:
+        def read(self):
+            return b"data"
+
+        def __str__(self):
+            return "https://example.com/video_file.mp4"
+
+    result = handler._convert_response(
+        base_config, base_request, "pred-file", [FakeFileOutput()]
+    )
+
+    assert result.video == "https://example.com/video_file.mp4"
+
+
+def test_convert_response_with_file_output_read_direct(
+    handler, base_config, base_request
+):
+    """Test conversion when output is a FileOutput with .read() (not in list)."""
+
+    class FakeFileOutput:
+        def read(self):
+            return b"data"
+
+        def __str__(self):
+            return "https://example.com/direct_file.mp4"
+
+    result = handler._convert_response(
+        base_config, base_request, "pred-direct-file", FakeFileOutput()
+    )
+
+    assert result.video == "https://example.com/direct_file.mp4"
+
+
+# ==================== Image Response Conversion: FileOutput objects ====================
+
+
+def test_convert_image_response_with_file_output_url(handler):
+    """Test image response conversion with FileOutput objects having .url attribute."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test image")
+
+    mock_file1 = MagicMock()
+    mock_file1.url = "https://example.com/image1.png"
+    mock_file2 = MagicMock()
+    mock_file2.url = "https://example.com/image2.png"
+
+    result = handler._convert_image_response(
+        config, request, "pred-img-url", [mock_file1, mock_file2]
+    )
+
+    assert len(result.images) == 2
+    assert result.images[0] == "https://example.com/image1.png"
+    assert result.images[1] == "https://example.com/image2.png"
+
+
+def test_convert_image_response_with_file_output_read(handler):
+    """Test image response conversion with FileOutput having .read() method."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    class FakeFileOutput:
+        def read(self):
+            return b"data"
+
+        def __str__(self):
+            return "https://example.com/image_read.png"
+
+    result = handler._convert_image_response(
+        config, request, "pred-img-read", [FakeFileOutput()]
+    )
+
+    assert len(result.images) == 1
+    assert result.images[0] == "https://example.com/image_read.png"
+
+
+def test_convert_image_response_string_output(handler):
+    """Test image response conversion with string output."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    result = handler._convert_image_response(
+        config, request, "pred-str", "https://example.com/single.png"
+    )
+
+    assert len(result.images) == 1
+    assert result.images[0] == "https://example.com/single.png"
+
+
+def test_convert_image_response_single_file_output_url(handler):
+    """Test image response conversion with single FileOutput (not in list)."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    mock_file = MagicMock()
+    mock_file.url = "https://example.com/single_file.png"
+
+    result = handler._convert_image_response(config, request, "pred-single", mock_file)
+
+    assert len(result.images) == 1
+    assert result.images[0] == "https://example.com/single_file.png"
+
+
+def test_convert_image_response_empty_list_raises_error(handler):
+    """Test that empty list output raises GenerationFailedError."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="test")
+
+    with pytest.raises(GenerationFailedError, match="Could not extract image URLs"):
+        handler._convert_image_response(config, request, "pred-empty", [])
+
+
+# ==================== Image Generation: async/sync ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_without_progress(handler):
+    """Test async image generation without progress callback."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="A beautiful sunset")
+
+    mock_async_client = AsyncMock()
+    mock_async_client.run = AsyncMock(return_value=["https://example.com/image.png"])
+
+    with patch(
+        "tarash.tarash_gateway.providers.replicate.AsyncReplicate",
+        return_value=mock_async_client,
+    ):
+        result = await handler.generate_image_async(config, request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert result.images[0] == "https://example.com/image.png"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_with_progress(handler):
+    """Test async image generation with progress callback and polling."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+        poll_interval=1,
+        max_poll_attempts=3,
+    )
+    request = ImageGenerationRequest(prompt="A sunset")
+
+    mock_prediction_processing = MagicMock()
+    mock_prediction_processing.id = "pred-img-async"
+    mock_prediction_processing.status = "processing"
+    mock_prediction_processing.progress = None
+    mock_prediction_processing.logs = None
+    mock_prediction_processing.error = None
+
+    mock_prediction_done = MagicMock()
+    mock_prediction_done.id = "pred-img-async"
+    mock_prediction_done.status = "succeeded"
+    mock_prediction_done.progress = None
+    mock_prediction_done.logs = None
+    mock_prediction_done.error = None
+    mock_prediction_done.output = ["https://example.com/image.png"]
+
+    mock_async_client = AsyncMock()
+    mock_async_client.predictions = AsyncMock()
+    mock_async_client.predictions.create = AsyncMock(
+        return_value=mock_prediction_processing
+    )
+    mock_async_client.predictions.get = AsyncMock(
+        side_effect=[mock_prediction_processing, mock_prediction_done]
+    )
+
+    progress_calls = []
+
+    async def progress_cb(update):
+        progress_calls.append(update)
+
+    with patch(
+        "tarash.tarash_gateway.providers.replicate.AsyncReplicate",
+        return_value=mock_async_client,
+    ):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await handler.generate_image_async(
+                config, request, on_progress=progress_cb
+            )
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+    assert len(progress_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_timeout(handler):
+    """Test async image generation timeout after max poll attempts."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+        poll_interval=1,
+        max_poll_attempts=2,
+    )
+    request = ImageGenerationRequest(prompt="A sunset")
+
+    mock_prediction = MagicMock()
+    mock_prediction.id = "pred-img-timeout"
+    mock_prediction.status = "processing"
+    mock_prediction.progress = None
+    mock_prediction.logs = None
+    mock_prediction.error = None
+
+    mock_async_client = AsyncMock()
+    mock_async_client.predictions = AsyncMock()
+    mock_async_client.predictions.create = AsyncMock(return_value=mock_prediction)
+    mock_async_client.predictions.get = AsyncMock(return_value=mock_prediction)
+
+    with patch(
+        "tarash.tarash_gateway.providers.replicate.AsyncReplicate",
+        return_value=mock_async_client,
+    ):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TimeoutError, match="timed out"):
+                await handler.generate_image_async(
+                    config, request, on_progress=lambda x: None
+                )
+
+
+def test_generate_image_sync_without_progress(handler):
+    """Test sync image generation without progress callback."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+    )
+    request = ImageGenerationRequest(prompt="A mountain")
+
+    mock_client = MagicMock()
+    mock_client.run.return_value = ["https://example.com/image.png"]
+
+    with patch(
+        "tarash.tarash_gateway.providers.replicate.Replicate",
+        return_value=mock_client,
+    ):
+        result = handler.generate_image(config, request)
+
+    assert result.status == "completed"
+    assert len(result.images) == 1
+
+
+def test_generate_image_sync_with_progress(handler):
+    """Test sync image generation with progress callback and polling."""
+    config = ImageGenerationConfig(
+        model="black-forest-labs/flux.2-pro",
+        provider="replicate",
+        api_key="test-key",
+        poll_interval=1,
+        max_poll_attempts=3,
+    )
+    request = ImageGenerationRequest(prompt="A forest")
+
+    mock_prediction_done = MagicMock()
+    mock_prediction_done.id = "pred-img-sync"
+    mock_prediction_done.status = "succeeded"
+    mock_prediction_done.progress = None
+    mock_prediction_done.logs = None
+    mock_prediction_done.error = None
+    mock_prediction_done.output = ["https://example.com/image.png"]
+
+    mock_client = MagicMock()
+    mock_client.predictions.create.return_value = mock_prediction_done
+    mock_client.predictions.get.return_value = mock_prediction_done
+
+    progress_calls = []
+
+    with patch(
+        "tarash.tarash_gateway.providers.replicate.Replicate",
+        return_value=mock_client,
+    ):
+        with patch("time.sleep"):
+            result = handler.generate_image(
+                config, request, on_progress=lambda x: progress_calls.append(x)
+            )
+
+    assert result.status == "completed"
+    assert len(progress_calls) >= 1

--- a/packages/tarash-gateway/tests/unit/video/providers/test_runway.py
+++ b/packages/tarash-gateway/tests/unit/video/providers/test_runway.py
@@ -7,6 +7,8 @@ import pytest
 from runwayml import BadRequestError
 from tarash.tarash_gateway.exceptions import (
     GenerationFailedError,
+    HTTPConnectionError,
+    HTTPError,
     TimeoutError,
     ValidationError,
 )
@@ -16,6 +18,8 @@ from tarash.tarash_gateway.models import (
 )
 from tarash.tarash_gateway.providers.runway import (
     RunwayProviderHandler,
+    _convert_media_to_file,
+    _extract_video_url,
     _get_endpoint_from_model,
     parse_runway_task_status,
 )
@@ -486,3 +490,228 @@ def test_handle_error_generic_error(handler, base_config, text_to_video_request)
 
     assert isinstance(result, GenerationFailedError)
     assert "Error while generating video" in str(result)
+
+
+def test_handle_error_api_timeout(handler, base_config, text_to_video_request):
+    """Test APITimeoutError maps to TimeoutError."""
+    from runwayml import APITimeoutError
+
+    ex = APITimeoutError.__new__(APITimeoutError)
+    ex.args = ("Request timed out",)
+
+    result = handler._handle_error(base_config, text_to_video_request, "test-id", ex)
+
+    assert isinstance(result, TimeoutError)
+    assert "timed out" in result.message
+    assert result.provider == "runway"
+    assert result.timeout_seconds == 600
+
+
+def test_handle_error_api_connection_error(handler, base_config, text_to_video_request):
+    """Test APIConnectionError maps to HTTPConnectionError."""
+    from runwayml import APIConnectionError
+
+    ex = APIConnectionError.__new__(APIConnectionError)
+    ex.args = ("Connection refused",)
+
+    result = handler._handle_error(base_config, text_to_video_request, "test-id", ex)
+
+    assert isinstance(result, HTTPConnectionError)
+    assert "Connection error" in result.message
+
+
+def test_handle_error_api_status_error_generic(
+    handler, base_config, text_to_video_request
+):
+    """Test generic APIStatusError (e.g. 500) maps to HTTPError."""
+    from runwayml import APIStatusError
+
+    ex = APIStatusError.__new__(APIStatusError)
+    ex.status_code = 500
+    ex.message = "Internal server error"
+    ex.body = {"error": "Internal server error"}
+    ex.args = ("Internal server error",)
+
+    result = handler._handle_error(base_config, text_to_video_request, "test-id", ex)
+
+    assert isinstance(result, HTTPError)
+    assert result.status_code == 500
+
+
+# ==================== Helper Function Tests ====================
+
+
+def test_extract_video_url_from_string():
+    """Test _extract_video_url with string output."""
+    assert (
+        _extract_video_url("https://example.com/video.mp4")
+        == "https://example.com/video.mp4"
+    )
+
+
+def test_extract_video_url_from_list():
+    """Test _extract_video_url with list output."""
+    assert (
+        _extract_video_url(["https://example.com/video.mp4"])
+        == "https://example.com/video.mp4"
+    )
+
+
+def test_extract_video_url_from_empty_list():
+    """Test _extract_video_url with empty list returns None."""
+    assert _extract_video_url([]) is None
+
+
+def test_extract_video_url_from_dict():
+    """Test _extract_video_url with dict output."""
+    assert (
+        _extract_video_url({"url": "https://example.com/video.mp4"})
+        == "https://example.com/video.mp4"
+    )
+
+
+def test_extract_video_url_from_dict_no_url():
+    """Test _extract_video_url with dict without url key returns None."""
+    assert _extract_video_url({"other": "data"}) is None
+
+
+def test_extract_video_url_from_unknown_type():
+    """Test _extract_video_url with unknown type returns None."""
+    assert _extract_video_url(12345) is None
+
+
+def test_convert_media_to_file_string():
+    """Test _convert_media_to_file with string URL."""
+    result = _convert_media_to_file("https://example.com/image.jpg", "image")
+    assert result == "https://example.com/image.jpg"
+
+
+def test_convert_media_to_file_dict_bytes():
+    """Test _convert_media_to_file with MediaContent dict."""
+    import io
+
+    media = {"content": b"fake-image-data", "content_type": "image/jpeg"}
+    result = _convert_media_to_file(media, "prompt_image")
+
+    assert isinstance(result, io.BytesIO)
+    assert result.name == "prompt_image.jpeg"
+    assert result.read() == b"fake-image-data"
+
+
+def test_convert_media_to_file_other_type():
+    """Test _convert_media_to_file with HttpUrl-like type falls through to str()."""
+    from unittest.mock import MagicMock
+
+    mock_url = MagicMock()
+    mock_url.__str__ = lambda self: "https://example.com/fallback.jpg"
+
+    result = _convert_media_to_file(mock_url, "image")
+    assert result == "https://example.com/fallback.jpg"
+
+
+# ==================== Unknown Model Tests ====================
+
+
+def test_get_endpoint_unknown_model_rejects_video():
+    """Test unknown model rejects video input."""
+    with pytest.raises(ValidationError, match="does not support video input"):
+        _get_endpoint_from_model("unknown-model-v1", False, True)
+
+
+def test_get_endpoint_unknown_model_image_to_video():
+    """Test unknown model with image input routes to image_to_video."""
+    assert _get_endpoint_from_model("unknown-model-v1", True, False) == "image_to_video"
+
+
+def test_get_endpoint_unknown_model_text_to_video():
+    """Test unknown model without inputs routes to text_to_video."""
+    assert _get_endpoint_from_model("unknown-model-v1", False, False) == "text_to_video"
+
+
+# ==================== Request Conversion: audio flag, seed, content_moderation ====================
+
+
+def test_convert_request_text_to_video_with_audio(handler, base_config):
+    """Test audio flag is passed for text-to-video endpoint."""
+    request = VideoGenerationRequest(prompt="Test", generate_audio=True)
+    endpoint, params = handler._convert_request(base_config, request)
+
+    assert endpoint == "text_to_video"
+    assert params["audio"] is True
+
+
+def test_convert_request_image_to_video_no_reference_images_error(handler):
+    """Test image-to-video endpoint raises when no reference image found."""
+    config = VideoGenerationConfig(
+        model="gen4_turbo",
+        provider="runway",
+        api_key="test-api-key",
+        timeout=600,
+    )
+    request = VideoGenerationRequest(
+        prompt="Test",
+        image_list=[{"type": "last_frame", "image": "https://example.com/img.jpg"}],
+    )
+    with pytest.raises(ValidationError, match="No reference image found"):
+        handler._convert_request(config, request)
+
+
+def test_convert_request_v2v_with_reference_images(handler):
+    """Test v2v endpoint passes reference images."""
+    config = VideoGenerationConfig(
+        model="gen4_aleph",
+        provider="runway",
+        api_key="test-api-key",
+        timeout=600,
+    )
+    request = VideoGenerationRequest(
+        prompt="Add elements",
+        video="https://example.com/video.mp4",
+        image_list=[
+            {"type": "reference", "image": "https://example.com/ref.jpg"},
+        ],
+        aspect_ratio="16:9",
+    )
+    endpoint, params = handler._convert_request(config, request)
+
+    assert endpoint == "video_to_video"
+    assert params["references"] == [
+        {"type": "image", "uri": "https://example.com/ref.jpg"}
+    ]
+
+
+def test_convert_request_v2v_seed_and_content_moderation(handler):
+    """Test v2v endpoint passes seed and content_moderation."""
+    config = VideoGenerationConfig(
+        model="gen4_aleph",
+        provider="runway",
+        api_key="test-api-key",
+        timeout=600,
+    )
+    request = VideoGenerationRequest(
+        prompt="Test",
+        video="https://example.com/video.mp4",
+        seed=99,
+        extra_params={"content_moderation": {"threshold": "low"}},
+    )
+    endpoint, params = handler._convert_request(config, request)
+
+    assert endpoint == "video_to_video"
+    assert params["seed"] == 99
+    assert params["content_moderation"] == {"threshold": "low"}
+
+
+# ==================== Image Generation: NotImplementedError ====================
+
+
+@pytest.mark.asyncio
+async def test_generate_image_async_not_implemented(handler):
+    """Test async image generation raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="does not support image generation"):
+        await handler.generate_image_async(None, None)
+
+
+def test_generate_image_sync_not_implemented(handler):
+    """Test sync image generation raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="does not support image generation"):
+        handler.generate_image(None, None)

--- a/packages/tarash-gateway/tests/unit/video/test_orchestrator.py
+++ b/packages/tarash-gateway/tests/unit/video/test_orchestrator.py
@@ -11,6 +11,14 @@ from tarash.tarash_gateway.exceptions import (
     ValidationError,
 )
 from tarash.tarash_gateway.models import (
+    AudioGenerationConfig,
+    ImageGenerationConfig,
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    STSRequest,
+    STSResponse,
+    TTSRequest,
+    TTSResponse,
     VideoGenerationConfig,
     VideoGenerationRequest,
     VideoGenerationResponse,
@@ -244,3 +252,1211 @@ def test_execute_sync_success_first_attempt():
     assert response.execution_metadata.total_attempts == 1
     assert response.execution_metadata.successful_attempt == 1
     assert response.execution_metadata.fallback_triggered is False
+
+
+# ==================== Video exhaustion tests ====================
+
+
+@pytest.mark.asyncio
+async def test_execute_async_all_providers_exhausted_raises_last_error():
+    """All providers fail with retryable errors — last error is raised."""
+    fallback_config = VideoGenerationConfig(
+        model="replicate/minimax",
+        provider="replicate",
+        api_key="replicate-key",
+    )
+    config = VideoGenerationConfig(
+        model="fal-ai/veo3.1",
+        provider="fal",
+        api_key="fal-key",
+        fallback_configs=[fallback_config],
+    )
+    request = VideoGenerationRequest(prompt="test prompt")
+
+    handler1 = AsyncMock()
+    handler1.generate_video_async.side_effect = HTTPError(
+        "Server error 1",
+        provider="fal",
+        model="fal-ai/veo3.1",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_video_async.side_effect = HTTPError(
+        "Server error 2",
+        provider="replicate",
+        model="replicate/minimax",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler",
+        side_effect=get_handler_mock,
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Server error 2"):
+            await orchestrator.execute_async(config, request)
+
+
+def test_execute_sync_all_providers_exhausted_raises_last_error():
+    """Sync: all providers fail with retryable errors — last error is raised."""
+    fallback_config = VideoGenerationConfig(
+        model="replicate/minimax",
+        provider="replicate",
+        api_key="replicate-key",
+    )
+    config = VideoGenerationConfig(
+        model="fal-ai/veo3.1",
+        provider="fal",
+        api_key="fal-key",
+        fallback_configs=[fallback_config],
+    )
+    request = VideoGenerationRequest(prompt="test prompt")
+
+    handler1 = MagicMock()
+    handler1.generate_video.side_effect = HTTPError(
+        "Server error 1",
+        provider="fal",
+        model="fal-ai/veo3.1",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_video.side_effect = HTTPError(
+        "Server error 2",
+        provider="replicate",
+        model="replicate/minimax",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler",
+        side_effect=get_handler_mock,
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Server error 2"):
+            orchestrator.execute_sync(config, request)
+
+
+def test_execute_sync_non_retryable_error_no_fallback():
+    """Sync: non-retryable errors stop the chain immediately."""
+    fallback_config = VideoGenerationConfig(
+        model="replicate/minimax",
+        provider="replicate",
+        api_key="replicate-key",
+    )
+    config = VideoGenerationConfig(
+        model="fal-ai/veo3.1",
+        provider="fal",
+        api_key="fal-key",
+        fallback_configs=[fallback_config],
+    )
+    request = VideoGenerationRequest(prompt="test prompt")
+
+    handler = MagicMock()
+    handler.generate_video.side_effect = ValidationError(
+        "Invalid prompt",
+        provider="fal",
+        model="fal-ai/veo3.1",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Invalid prompt"):
+            orchestrator.execute_sync(config, request)
+
+
+def test_execute_sync_fallback_on_retryable_error():
+    """Sync: fallback triggered on retryable error, second provider succeeds."""
+    fallback_config = VideoGenerationConfig(
+        model="replicate/minimax",
+        provider="replicate",
+        api_key="replicate-key",
+    )
+    config = VideoGenerationConfig(
+        model="fal-ai/veo3.1",
+        provider="fal",
+        api_key="fal-key",
+        fallback_configs=[fallback_config],
+    )
+    request = VideoGenerationRequest(prompt="test prompt")
+
+    handler1 = MagicMock()
+    handler1.generate_video.side_effect = HTTPError(
+        "Internal server error",
+        provider="fal",
+        model="fal-ai/veo3.1",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_video.return_value = VideoGenerationResponse(
+        request_id="req-fallback",
+        video="https://example.com/video2.mp4",
+        status="completed",
+        raw_response={"status": "completed"},
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler",
+        side_effect=get_handler_mock,
+    ):
+        orchestrator = ExecutionOrchestrator()
+        response = orchestrator.execute_sync(config, request)
+
+    assert response.request_id == "req-fallback"
+    assert response.execution_metadata.total_attempts == 2
+    assert response.execution_metadata.fallback_triggered is True
+
+
+# ==================== Image fallback chain tests ====================
+
+
+def test_collect_image_fallback_chain_no_fallbacks():
+    """Image: single config yields chain of length 1."""
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="test-key",
+    )
+    chain = ExecutionOrchestrator.collect_image_fallback_chain(config)
+    assert len(chain) == 1
+    assert chain[0].model == "dall-e-3"
+
+
+def test_collect_image_fallback_chain_nested():
+    """Image: nested fallbacks are collected depth-first."""
+    fb2 = ImageGenerationConfig(
+        model="stability/sdxl",
+        provider="stability",
+        api_key="key-3",
+    )
+    fb1 = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+        fallback_configs=[fb2],
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb1],
+    )
+    chain = ExecutionOrchestrator.collect_image_fallback_chain(config)
+    assert len(chain) == 3
+    assert [c.model for c in chain] == ["dall-e-3", "fal-ai/flux/dev", "stability/sdxl"]
+
+
+# ==================== Image generation tests ====================
+
+
+@pytest.fixture
+def _image_config():
+    return ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="test-key",
+    )
+
+
+@pytest.fixture
+def _image_request():
+    return ImageGenerationRequest(prompt="a cat")
+
+
+@pytest.fixture
+def _image_response():
+    return ImageGenerationResponse(
+        request_id="img-123",
+        images=["https://example.com/img.png"],
+        status="completed",
+        raw_response={"ok": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_image_async_success(
+    _image_config, _image_request, _image_response
+):
+    """Image async: success on first attempt attaches metadata."""
+    handler = AsyncMock()
+    handler.generate_image_async.return_value = _image_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_image_async(_image_config, _image_request)
+
+    assert resp.request_id == "img-123"
+    assert resp.execution_metadata is not None
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+@pytest.mark.asyncio
+async def test_execute_image_async_fallback_on_retryable(
+    _image_request, _image_response
+):
+    """Image async: retryable error triggers fallback to next provider."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_image_async.side_effect = HTTPError(
+        "Server error",
+        provider="openai",
+        model="dall-e-3",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_image_async.return_value = _image_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_image_async(config, _image_request)
+
+    assert resp.request_id == "img-123"
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+@pytest.mark.asyncio
+async def test_execute_image_async_non_retryable_stops(_image_request):
+    """Image async: non-retryable error stops chain immediately."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = AsyncMock()
+    handler.generate_image_async.side_effect = ValidationError(
+        "Bad size",
+        provider="openai",
+        model="dall-e-3",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad size"):
+            await orchestrator.execute_image_async(config, _image_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_image_async_all_exhausted(_image_request):
+    """Image async: all providers fail with retryable errors — raises last."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_image_async.side_effect = HTTPError(
+        "Err 1",
+        provider="openai",
+        model="dall-e-3",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_image_async.side_effect = HTTPError(
+        "Err 2",
+        provider="fal",
+        model="fal-ai/flux/dev",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            await orchestrator.execute_image_async(config, _image_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_image_async_not_implemented_propagates(
+    _image_config, _image_request
+):
+    """Image async: NotImplementedError propagates without fallback."""
+    handler = AsyncMock()
+    handler.generate_image_async.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            await orchestrator.execute_image_async(_image_config, _image_request)
+
+
+def test_execute_image_sync_success(_image_config, _image_request, _image_response):
+    """Image sync: success on first attempt."""
+    handler = MagicMock()
+    handler.generate_image.return_value = _image_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_image_sync(_image_config, _image_request)
+
+    assert resp.request_id == "img-123"
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+def test_execute_image_sync_fallback_on_retryable(_image_request, _image_response):
+    """Image sync: retryable error triggers fallback."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_image.side_effect = HTTPError(
+        "Server error",
+        provider="openai",
+        model="dall-e-3",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_image.return_value = _image_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_image_sync(config, _image_request)
+
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+def test_execute_image_sync_non_retryable_stops(_image_request):
+    """Image sync: non-retryable error stops chain."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = MagicMock()
+    handler.generate_image.side_effect = ValidationError(
+        "Bad size",
+        provider="openai",
+        model="dall-e-3",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad size"):
+            orchestrator.execute_image_sync(config, _image_request)
+
+
+def test_execute_image_sync_all_exhausted(_image_request):
+    """Image sync: all providers fail — raises last error."""
+    fb = ImageGenerationConfig(
+        model="fal-ai/flux/dev",
+        provider="fal",
+        api_key="key-2",
+    )
+    config = ImageGenerationConfig(
+        model="dall-e-3",
+        provider="openai",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_image.side_effect = HTTPError(
+        "Err 1",
+        provider="openai",
+        model="dall-e-3",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_image.side_effect = HTTPError(
+        "Err 2",
+        provider="fal",
+        model="fal-ai/flux/dev",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            orchestrator.execute_image_sync(config, _image_request)
+
+
+def test_execute_image_sync_not_implemented_propagates(_image_config, _image_request):
+    """Image sync: NotImplementedError propagates without fallback."""
+    handler = MagicMock()
+    handler.generate_image.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            orchestrator.execute_image_sync(_image_config, _image_request)
+
+
+# ==================== Audio fallback chain tests ====================
+
+
+def test_collect_audio_fallback_chain_no_fallbacks():
+    """Audio: single config yields chain of length 1."""
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="test-key",
+    )
+    chain = ExecutionOrchestrator.collect_audio_fallback_chain(config)
+    assert len(chain) == 1
+    assert chain[0].model == "eleven_multilingual_v2"
+
+
+def test_collect_audio_fallback_chain_nested():
+    """Audio: nested fallbacks are collected depth-first."""
+    fb2 = AudioGenerationConfig(
+        model="fal-ai/minimax/speech-2.8-hd",
+        provider="fal",
+        api_key="key-3",
+    )
+    fb1 = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+        fallback_configs=[fb2],
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb1],
+    )
+    chain = ExecutionOrchestrator.collect_audio_fallback_chain(config)
+    assert len(chain) == 3
+    assert [c.model for c in chain] == [
+        "eleven_multilingual_v2",
+        "sonic-3",
+        "fal-ai/minimax/speech-2.8-hd",
+    ]
+
+
+# ==================== TTS generation tests ====================
+
+
+@pytest.fixture
+def _audio_config():
+    return AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="test-key",
+    )
+
+
+@pytest.fixture
+def _tts_request():
+    return TTSRequest(text="Hello world")
+
+
+@pytest.fixture
+def _tts_response():
+    return TTSResponse(
+        request_id="tts-123",
+        audio="base64audiodata",
+        status="completed",
+        raw_response={"ok": True},
+    )
+
+
+@pytest.fixture
+def _sts_request():
+    return STSRequest(audio=b"raw-audio-bytes", voice_id="voice-1")
+
+
+@pytest.fixture
+def _sts_response():
+    return STSResponse(
+        request_id="sts-123",
+        audio="base64audiodata",
+        status="completed",
+        raw_response={"ok": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_tts_async_success(_audio_config, _tts_request, _tts_response):
+    """TTS async: success on first attempt attaches metadata."""
+    handler = AsyncMock()
+    handler.generate_tts_async.return_value = _tts_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_tts_async(_audio_config, _tts_request)
+
+    assert resp.request_id == "tts-123"
+    assert resp.execution_metadata is not None
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+@pytest.mark.asyncio
+async def test_execute_tts_async_fallback_on_retryable(_tts_request, _tts_response):
+    """TTS async: retryable error triggers fallback."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_tts_async.side_effect = HTTPError(
+        "Server error",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_tts_async.return_value = _tts_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_tts_async(config, _tts_request)
+
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+@pytest.mark.asyncio
+async def test_execute_tts_async_non_retryable_stops(_tts_request):
+    """TTS async: non-retryable error stops chain."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = AsyncMock()
+    handler.generate_tts_async.side_effect = ValidationError(
+        "Bad voice",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad voice"):
+            await orchestrator.execute_tts_async(config, _tts_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_tts_async_all_exhausted(_tts_request):
+    """TTS async: all providers fail — raises last error."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_tts_async.side_effect = HTTPError(
+        "Err 1",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_tts_async.side_effect = HTTPError(
+        "Err 2",
+        provider="cartesia",
+        model="sonic-3",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            await orchestrator.execute_tts_async(config, _tts_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_tts_async_not_implemented_propagates(
+    _audio_config, _tts_request
+):
+    """TTS async: NotImplementedError propagates without fallback."""
+    handler = AsyncMock()
+    handler.generate_tts_async.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            await orchestrator.execute_tts_async(_audio_config, _tts_request)
+
+
+def test_execute_tts_sync_success(_audio_config, _tts_request, _tts_response):
+    """TTS sync: success on first attempt."""
+    handler = MagicMock()
+    handler.generate_tts.return_value = _tts_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_tts_sync(_audio_config, _tts_request)
+
+    assert resp.request_id == "tts-123"
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+def test_execute_tts_sync_fallback_on_retryable(_tts_request, _tts_response):
+    """TTS sync: retryable error triggers fallback."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_tts.side_effect = HTTPError(
+        "Server error",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_tts.return_value = _tts_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_tts_sync(config, _tts_request)
+
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+def test_execute_tts_sync_non_retryable_stops(_tts_request):
+    """TTS sync: non-retryable error stops chain."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = MagicMock()
+    handler.generate_tts.side_effect = ValidationError(
+        "Bad voice",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad voice"):
+            orchestrator.execute_tts_sync(config, _tts_request)
+
+
+def test_execute_tts_sync_all_exhausted(_tts_request):
+    """TTS sync: all providers fail — raises last error."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_tts.side_effect = HTTPError(
+        "Err 1",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_tts.side_effect = HTTPError(
+        "Err 2",
+        provider="cartesia",
+        model="sonic-3",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            orchestrator.execute_tts_sync(config, _tts_request)
+
+
+def test_execute_tts_sync_not_implemented_propagates(_audio_config, _tts_request):
+    """TTS sync: NotImplementedError propagates without fallback."""
+    handler = MagicMock()
+    handler.generate_tts.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            orchestrator.execute_tts_sync(_audio_config, _tts_request)
+
+
+# ==================== STS generation tests ====================
+
+
+@pytest.mark.asyncio
+async def test_execute_sts_async_success(_audio_config, _sts_request, _sts_response):
+    """STS async: success on first attempt attaches metadata."""
+    handler = AsyncMock()
+    handler.generate_sts_async.return_value = _sts_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_sts_async(_audio_config, _sts_request)
+
+    assert resp.request_id == "sts-123"
+    assert resp.execution_metadata is not None
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+@pytest.mark.asyncio
+async def test_execute_sts_async_fallback_on_retryable(_sts_request, _sts_response):
+    """STS async: retryable error triggers fallback."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_sts_async.side_effect = HTTPError(
+        "Server error",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_sts_async.return_value = _sts_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = await orchestrator.execute_sts_async(config, _sts_request)
+
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+@pytest.mark.asyncio
+async def test_execute_sts_async_non_retryable_stops(_sts_request):
+    """STS async: non-retryable error stops chain."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = AsyncMock()
+    handler.generate_sts_async.side_effect = ValidationError(
+        "Bad voice",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad voice"):
+            await orchestrator.execute_sts_async(config, _sts_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_sts_async_all_exhausted(_sts_request):
+    """STS async: all providers fail — raises last error."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = AsyncMock()
+    handler1.generate_sts_async.side_effect = HTTPError(
+        "Err 1",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = AsyncMock()
+    handler2.generate_sts_async.side_effect = HTTPError(
+        "Err 2",
+        provider="cartesia",
+        model="sonic-3",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            await orchestrator.execute_sts_async(config, _sts_request)
+
+
+@pytest.mark.asyncio
+async def test_execute_sts_async_not_implemented_propagates(
+    _audio_config, _sts_request
+):
+    """STS async: NotImplementedError propagates without fallback."""
+    handler = AsyncMock()
+    handler.generate_sts_async.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            await orchestrator.execute_sts_async(_audio_config, _sts_request)
+
+
+def test_execute_sts_sync_success(_audio_config, _sts_request, _sts_response):
+    """STS sync: success on first attempt."""
+    handler = MagicMock()
+    handler.generate_sts.return_value = _sts_response
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_sts_sync(_audio_config, _sts_request)
+
+    assert resp.request_id == "sts-123"
+    assert resp.execution_metadata.total_attempts == 1
+    assert resp.execution_metadata.fallback_triggered is False
+
+
+def test_execute_sts_sync_fallback_on_retryable(_sts_request, _sts_response):
+    """STS sync: retryable error triggers fallback."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_sts.side_effect = HTTPError(
+        "Server error",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_sts.return_value = _sts_response
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        resp = orchestrator.execute_sts_sync(config, _sts_request)
+
+    assert resp.execution_metadata.total_attempts == 2
+    assert resp.execution_metadata.fallback_triggered is True
+
+
+def test_execute_sts_sync_non_retryable_stops(_sts_request):
+    """STS sync: non-retryable error stops chain."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler = MagicMock()
+    handler.generate_sts.side_effect = ValidationError(
+        "Bad voice",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+    )
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(ValidationError, match="Bad voice"):
+            orchestrator.execute_sts_sync(config, _sts_request)
+
+
+def test_execute_sts_sync_all_exhausted(_sts_request):
+    """STS sync: all providers fail — raises last error."""
+    fb = AudioGenerationConfig(
+        model="sonic-3",
+        provider="cartesia",
+        api_key="key-2",
+    )
+    config = AudioGenerationConfig(
+        model="eleven_multilingual_v2",
+        provider="elevenlabs",
+        api_key="key-1",
+        fallback_configs=[fb],
+    )
+
+    handler1 = MagicMock()
+    handler1.generate_sts.side_effect = HTTPError(
+        "Err 1",
+        provider="elevenlabs",
+        model="eleven_multilingual_v2",
+        status_code=500,
+    )
+    handler2 = MagicMock()
+    handler2.generate_sts.side_effect = HTTPError(
+        "Err 2",
+        provider="cartesia",
+        model="sonic-3",
+        status_code=502,
+    )
+
+    handlers = [handler1, handler2]
+    call_count = 0
+
+    def get_handler_mock(cfg):
+        nonlocal call_count
+        h = handlers[call_count]
+        call_count += 1
+        return h
+
+    with patch(
+        "tarash.tarash_gateway.orchestrator.get_handler", side_effect=get_handler_mock
+    ):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(HTTPError, match="Err 2"):
+            orchestrator.execute_sts_sync(config, _sts_request)
+
+
+def test_execute_sts_sync_not_implemented_propagates(_audio_config, _sts_request):
+    """STS sync: NotImplementedError propagates without fallback."""
+    handler = MagicMock()
+    handler.generate_sts.side_effect = NotImplementedError("not supported")
+
+    with patch("tarash.tarash_gateway.orchestrator.get_handler", return_value=handler):
+        orchestrator = ExecutionOrchestrator()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            orchestrator.execute_sts_sync(_audio_config, _sts_request)


### PR DESCRIPTION
## Summary
- Add coverage-guard skill for enforcing test coverage thresholds
- Add unit tests for video providers (Fal, OpenAI, Replicate, Runway) covering error handling, field mapping, and response parsing
- Add unit tests for image providers (Google, Stability) covering generation workflows and error scenarios
- Add comprehensive orchestrator tests for image, audio, TTS, and STS generation flows

## Test plan
- [ ] Run `uv run pytest packages/tarash-gateway/tests/unit/` and verify all new tests pass
- [ ] Run `uv run pytest --cov` and confirm coverage meets 90% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)